### PR TITLE
Make generator output directory configurable

### DIFF
--- a/core/src/test/com/kakarote/generator/Generator.java
+++ b/core/src/test/com/kakarote/generator/Generator.java
@@ -15,6 +15,7 @@ import com.baomidou.mybatisplus.generator.config.rules.NamingStrategy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.nio.file.Paths;
 
 
 public class Generator {
@@ -32,9 +33,16 @@ public class Generator {
         generator.execute();
     }
 
-    private static GlobalConfig getGlobalConfig(){
+    static GlobalConfig getGlobalConfig(){
         GlobalConfig globalConfig = new GlobalConfig();
-        globalConfig.setOutputDir("D://generator/src/main/java");
+        String outputDir = System.getenv("GENERATOR_OUTPUT_DIR");
+        if (outputDir == null || "".equals(outputDir)) {
+            outputDir = System.getProperty("generator.output.dir");
+        }
+        if (outputDir == null || "".equals(outputDir)) {
+            outputDir = Paths.get(System.getProperty("java.io.tmpdir"), "generator").toString();
+        }
+        globalConfig.setOutputDir(outputDir);
         globalConfig.setAuthor("zhangzhiwei");
         globalConfig.setOpen(false);
         globalConfig.setKotlin(false);

--- a/core/src/test/com/kakarote/generator/GeneratorTest.java
+++ b/core/src/test/com/kakarote/generator/GeneratorTest.java
@@ -1,0 +1,19 @@
+package com.kakarote.generator;
+
+import com.baomidou.mybatisplus.generator.config.GlobalConfig;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GeneratorTest {
+    @Test
+    public void usesConfiguredOutputDir() throws Exception {
+        Path dir = Files.createTempDirectory("generator-test");
+        System.setProperty("generator.output.dir", dir.toString());
+        GlobalConfig config = Generator.getGlobalConfig();
+        assertEquals(dir.toString(), config.getOutputDir());
+    }
+}


### PR DESCRIPTION
## Summary
- allow specifying `GENERATOR_OUTPUT_DIR` or `generator.output.dir` for code generation
- default to a temp directory when no path provided
- add a small JUnit test demonstrating configurable output path

## Testing
- `mvn -pl core test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c233f3a483299952d22094881311